### PR TITLE
Fixed fragment shader input

### DIFF
--- a/Runtime/Shaders/AtmosphericScattering.shader
+++ b/Runtime/Shaders/AtmosphericScattering.shader
@@ -150,7 +150,7 @@ Shader "Hidden/AtmosphericScattering"
 				return o;
 			}
 
-			float4 fragDir(v2f i) : SV_Target
+			float4 fragDir(v2p i) : SV_Target
 			{
 				float cosAngle = i.uv.x * 1.1 - 0.1;// *2.0 - 1.0;
                 float sinAngle = sqrt(saturate(1 - cosAngle * cosAngle));
@@ -196,7 +196,7 @@ Shader "Hidden/AtmosphericScattering"
 				return o;
 			}
 
-			float4 fragDir(v2f i) : SV_Target
+			float4 fragDir(v2p i) : SV_Target
 			{
 				float cosAngle = i.uv.x * 1.1 - 0.1;// *2.0 - 1.0;
 				
@@ -282,7 +282,7 @@ Shader "Hidden/AtmosphericScattering"
 				return g;
 			}
 
-			float4 fragDir(v2f i) : COLOR0
+			float4 fragDir(PSInput i) : COLOR0
 			{
 				float2 uv = i.uv.xy;
 				float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, uv);


### PR DESCRIPTION
Shader didn't compile in mac (Metal) because the input struct was didn't have the right properties.
I checked and it looks like there was a mistype and misuse of the wrong struct.
Maybe it compiled and work on windows because directx accepts the cast or something, but in Metal it didn't.

I tested on both windows and mac and it seems to visually work the same.